### PR TITLE
n1sdp: enable pcie for remote n1sdp chip

### DIFF
--- a/product/n1sdp/module/n1sdp_pcie/src/mod_n1sdp_pcie.c
+++ b/product/n1sdp/module/n1sdp_pcie/src/mod_n1sdp_pcie.c
@@ -710,12 +710,6 @@ static int n1sdp_pcie_start(fwk_id_t id)
     if (dev_ctx == NULL)
         return FWK_E_PARAM;
 
-    /* Do not initialize PCIe RP in slave chip */
-    if (!dev_ctx->config->ccix_capable) {
-        if (n1sdp_get_chipid() != 0)
-            return FWK_SUCCESS;
-    }
-
     return fwk_notification_subscribe(
         mod_clock_notification_id_state_changed,
         FWK_ID_ELEMENT(FWK_MODULE_IDX_CLOCK, CLOCK_IDX_INTERCONNECT),


### PR DESCRIPTION
Removed the condition which stops the initialization and enabling
of PCIe in Remote Chip.

Change-Id: Ie2dcb3118efb73ede0d95af80364522216f59f9d
Signed-off-by: Sayanta Pattanayak <sayanta.pattanayak@arm.com>